### PR TITLE
Return tests from init

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ npm install @deriv-experiments/abcd
 Then, import the library in your JavaScript or TypeScript code:
 
 ```javascript
-import abcd, { abTests } from '@deriv-experiments/abcd';
+import abcd from '@deriv-experiments/abcd';
 
-abcd([
+const tests = abcd([
   {
     "name": "header",
     "variants": {
@@ -69,7 +69,7 @@ abcd([
   }
 ]);
 
-if (abTests.greeting === 'everyone') {
+if (tests.greeting === 'everyone') {
   alert('hello')
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@deriv-experiments/abcd",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@deriv-experiments/abcd",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jsdom": "^21.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deriv-experiments/abcd",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": false,
   "type": "module",
   "description": "A minimalistic and easy-to-use A/B testing library that enables you to effortlessly set up and manage A/B tests on your website. It is designed to be straightforward, requiring minimal configuration, and ensuring a quick and efficient way to test different variations of your site.",

--- a/tests/helpers/mockDom.ts
+++ b/tests/helpers/mockDom.ts
@@ -1,4 +1,6 @@
-import { JSDOM } from 'jsdom';
+import { JSDOM, CookieJar } from 'jsdom';
+
+const cookieJar = new CookieJar();
 
 export default function reset (): void {
   const dom = new JSDOM(`
@@ -10,7 +12,10 @@ export default function reset (): void {
       <body>
       </body>
     </html>
-  `);
+  `, {
+    url: 'http://localhost/',
+    cookieJar
+  });
 
   global.window = dom.window;
   global.document = dom.window.document;

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -192,3 +192,30 @@ test('it exports selected test variants', (t) => {
   t.equal(abTests.greeting, 'test', 'Selected greeting variant is exported');
   t.equal(abTests.color, 'blue', 'Selected color variant is exported');
 });
+
+test('it resets invalid variants', (t) => {
+  resetDom();
+
+  document.cookie = 'ab-greeting=woops';
+  document.cookie = 'ab-color=blue';
+
+  const tests = abcd([
+    {
+      name: 'greeting',
+      variants: {
+        control: 0.5,
+        test: 0.5
+      }
+    },
+    {
+      name: 'color',
+      variants: {
+        control: 0.5,
+        blue: 0.5
+      }
+    }
+  ]);
+
+  t.notEqual(tests.greeting, 'woops', 'Selected greeting is reset');
+  t.equal(tests.color, 'blue', 'Selected color variant is exported');
+});


### PR DESCRIPTION
Instead of importing a global abTests, you can get the tests from the returned init.

```javascript
import abcd from '@deriv-experiments/abcd';

const tests = abcd([
  {
    "name": "header",
    "variants": {
      "control": 0.8,
      "visible": 0.2
    }
  },
  {
    "name": "greeting",
    "variants": {
      "control": 0.5,
      "everyone": 0.25,
      "testers": 0.25
    }
  }
]);

if (tests.greeting === 'everyone') {
  alert('hello')
}
```